### PR TITLE
Fix decoding issue (#9) and improve kernel patch script.

### DIFF
--- a/kernel.patch
+++ b/kernel.patch
@@ -1,0 +1,13 @@
+diff --git a/net/bluetooth/l2cap_sock.c b/net/bluetooth/l2cap_sock.c
+index eebe25610..64db1db3f 100644
+--- a/net/bluetooth/l2cap_sock.c
++++ b/net/bluetooth/l2cap_sock.c
+@@ -1825,7 +1825,7 @@ static void l2cap_sock_init(struct sock *sk, struct sock *parent)
+                        break;
+                }
+ 
+-               chan->imtu = L2CAP_DEFAULT_MTU;
++               chan->imtu = 0;
+                chan->omtu = 0;
+                if (!disable_ertm && sk->sk_type == SOCK_STREAM) {
+                        chan->mode = L2CAP_MODE_ERTM;

--- a/libldacdec.c
+++ b/libldacdec.c
@@ -427,7 +427,7 @@ static void pcmFloatToInt( frame_t *this, int32_t *pcmOut )
     {
         for( int ch=0; ch<this->channelCount; ++ch, ++i )
         {
-            pcmOut[i] = Round(this->channels[ch].pcm[smpl]*(1<<16));
+            pcmOut[i] = Round(this->channels[ch].pcm[smpl]*(1<<15));
         }
     }
 }

--- a/patch-kernel.sh
+++ b/patch-kernel.sh
@@ -155,6 +155,23 @@ fi
 
 cd linux-*
 
+if [[ "$DEB_BUILD" == 1 ]]; then
+	out=$(dpkg-checkbuilddeps 2>&1 >/dev/null || true)
+
+	if [[ ! -z "$output" ]]; then
+		depln=$(echo "$out" | sed -n 's/.*Unmet build dependencies: //p')
+
+		if [[ ! -z "$deps_line" ]]; then
+			deps=$(echo "$depln" \
+			  | sed -E 's/\([^)]*\)//g' \
+			  | sed -E 's/([[:alnum:]._:+-]+)\s*\|\s*[[:alnum:]._:+-]+/\1/g')
+
+			echo " - Installing missing build dependencies."
+			sudo apt install -y $deps_clean
+		fi
+	fi
+fi
+
 if patch -sfp0 --ignore-whitespace --dry-run net/bluetooth/l2cap_sock.c < "$PATCH" &>/dev/null; then
     if patch -s --ignore-whitespace net/bluetooth/l2cap_sock.c < "$PATCH" &>/dev/null; then
         echo " - Applied patch to net/bluetooth/l2cap_sock.c."

--- a/patch-kernel.sh
+++ b/patch-kernel.sh
@@ -27,11 +27,12 @@ fi
 
 if ! grep -q "^deb-src" /etc/apt/sources.list /etc/apt/sources.list.d/*; then
     echo " - Error: Source repositories are disabled or not configured in your /etc/apt/sources.list. You need to enable them for this script to work." 1>&2
+    echo " - Note:  If you're compiling for a Raspberry Pi, you also need to enable source repositories in /etc/apt/sources.list.d/raspi.conf." 1>&2
     exit 1
 fi
 
 if [[ "$MORE" -gt 1 ]]; then
-    echo " - Warning: You set \$MORE to $MORE, which is greater than 1, and this is unsafe. I recommend you to set it to 0 or 1." 1>&2
+    echo " - Warning: You set \$MORE to $MORE, which is greater than 1, and this may slow down the build. I recommend you to set it to 0 or 1." 1>&2
 fi
 
 
@@ -133,7 +134,7 @@ if [ -e "$WORKDIR" ]; then
     rm -r "$WORKDIR"
 fi
 
-mkdir "$WORKDIR" || abort
+mkdir -p "$WORKDIR" || abort
 cd "$WORKDIR" || abort
 
 echo " - Preparing the system to compile the kernel..."
@@ -158,16 +159,16 @@ cd linux-*
 if [[ "$DEB_BUILD" == 1 ]]; then
 	out=$(dpkg-checkbuilddeps 2>&1 >/dev/null || true)
 
-	if [[ ! -z "$output" ]]; then
+	if [[ ! -z "$out" ]]; then
 		depln=$(echo "$out" | sed -n 's/.*Unmet build dependencies: //p')
 
-		if [[ ! -z "$deps_line" ]]; then
+		if [[ ! -z "$depln" ]]; then
 			deps=$(echo "$depln" \
 			  | sed -E 's/\([^)]*\)//g' \
 			  | sed -E 's/([[:alnum:]._:+-]+)\s*\|\s*[[:alnum:]._:+-]+/\1/g')
 
 			echo " - Installing missing build dependencies."
-			sudo apt install -y $deps_clean
+			sudo apt install -y $deps
 		fi
 	fi
 fi


### PR DESCRIPTION
This PR fixes the issue reported into #9 and applies some fixes to the patch-kernel.sh script:
- On a Raspberry Pi it will always build the latest version available instead of the one inside the `raspberrypi-firmware`;
- You can choose whether to compile using `debhelper` or simply through `make`;
- Backups are always kept and never deleted, so the original kernel is always available.